### PR TITLE
Ansible galaxy requirement for CSP module

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,6 @@
 
 - src: rhtconsulting.jboss_common
   name: jboss_common
+
+- src: sabre1041.redhat-csp-download
+  name: redhat-csp-download


### PR DESCRIPTION
Added a requirement to retrieve the `redhat-csp-download` module from Ansible galaxy for #24 